### PR TITLE
Define base url/path constants earlier and fix installation issue

### DIFF
--- a/includes/TkEventWeather__InstallIndicator.php
+++ b/includes/TkEventWeather__InstallIndicator.php
@@ -88,7 +88,7 @@ class TkEventWeather__InstallIndicator extends TkEventWeather__OptionsManager {
      */
     public function getPluginHeaderValue($key) {
         // Read the string from the comment header of the main plugin file
-        $data = file_get_contents($this->getPluginDir() . DIRECTORY_SEPARATOR . $this->getMainPluginFileName());
+        $data = file_get_contents( $this->getPluginDir() . $this->getMainPluginFileName());
         $match = array();
         preg_match('/' . $key . ':\s*(\S+)/', $data, $match);
         if (count($match) >= 1) {
@@ -106,7 +106,7 @@ class TkEventWeather__InstallIndicator extends TkEventWeather__OptionsManager {
      * @link https://developer.wordpress.org/reference/functions/plugin_dir_path/
      */
     protected function getPluginDir() {
-        return TkEventWeather__FuncSetup::plugin_dir_url_root();
+        return TkEventWeather__FuncSetup::plugin_dir_path_root();
     }
 
     /**

--- a/tk-event-weather.php
+++ b/tk-event-weather.php
@@ -31,6 +31,9 @@
     If not, see http://www.gnu.org/licenses/gpl-3.0.html
 */
 
+define( 'TK_EVENT_WEATHER_PLUGIN_ROOT_DIR', plugin_dir_path( __FILE__ ) ); // e.g. /Users/cmp/Documents/git/GitHub/tk-event-weather/
+define( 'TK_EVENT_WEATHER_PLUGIN_ROOT_URL', plugin_dir_url( __FILE__ ) );  // e.g. http://some.site/wp-content/plugins/tk-event-weather/
+
 $TkEventWeather__minimalRequiredPhpVersion = '5.0';
 
 /**
@@ -85,7 +88,3 @@ if (TkEventWeather__PhpVersionCheck()) {
     include_once('includes/TkEventWeather__init.php');
     TkEventWeather__init(__FILE__);
 }
-
-
-// Required for Template Loader. Also used elsewhere.
-define( 'TK_EVENT_WEATHER_PLUGIN_ROOT_DIR', plugin_dir_path( __FILE__ ) ); // e.g. /Users/cmp/Documents/git/GitHub/tk-event-weather/


### PR DESCRIPTION
Stops a 'garbage generated' warning happening on plugin activation (not everyone would hit this - but it still doesn't do its job on initial activation) and ensures `TkEventWeather__InstallIndicator::getPluginHeaderValue()` can find the information it is looking for.
- Adds a definition for the plugin base URL
- Places that and the existing plugin base dir definition at the top of the main plugin file
- Ensures we form a correct and valid filepath in `TkEventWeather__InstallIndicator::getPluginHeaderValue()`

To see the problem it solves, test with the existing code and:
- Deactivate the plugin
- Enable WP_DEBUG
- Delete the `TkEventWeather_*` options from the db
- Reactivate the plugin
