### PR TITLE
1.5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,24 +3,42 @@
   "description": "Display beautiful, accurate, and free hourly weather forecasts between a start and end time. Perfect for event calendars.",
   "type": "project",
   "require": {
-    "php": ">=5.4",
-    "freemius/wordpress-sdk": ">=1.2.3",
-    "gamajo/template-loader": ">=1.3",
-    "climacons-webfont/climacons-webfont": ">=1.0.0"
+    "php": ">=5.6",
+    "freemius/wordpress-sdk": "~2.2",
+    "gamajo/template-loader": "~1.3",
+    "climacons-webfont/climacons-webfont": "~1.0"
   },
   "license": "GPL-3.0+",
   "authors": [
     {
       "name": "TourKick LLC (Clifford Paulick)",
       "email": "tko+tkeventw@tourkick.com",
+      "homepage": "https://tourkick.com/",
       "role": "Developer"
     }
   ],
   "minimum-stability": "stable",
+  "archive": {
+    "exclude": [
+      "!vendor/*",
+      "*.zip",
+      ".gitignore",
+      ".github",
+      ".travis.yml",
+      "composer.phar",
+      "composer.json",
+      "composer.lock",
+      "phpunit.xml",
+      "README.md"
+    ]
+  },
   "autoload": {
     "psr-4": {
       "TKEventWeather\\": "src/"
     }
   },
-  "optimize-autoloader": true
+  "config": {
+    "archive-format": "zip",
+    "optimize-autoloader": true
+  }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "551e4ccc20083b645a457c2b8cb89c2a",
+    "content-hash": "53754776703700e0448fa7e3647b083d",
     "packages": [
         {
             "name": "climacons-webfont/climacons-webfont",
@@ -46,16 +46,16 @@
         },
         {
             "name": "freemius/wordpress-sdk",
-            "version": "1.2.3",
+            "version": "2.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Freemius/wordpress-sdk.git",
-                "reference": "5b420d7c7e4eb3fe164a6ccd4956c8b591753550"
+                "reference": "a4cc02a705639bcc64b5b55b8732432986b1b228"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Freemius/wordpress-sdk/zipball/5b420d7c7e4eb3fe164a6ccd4956c8b591753550",
-                "reference": "5b420d7c7e4eb3fe164a6ccd4956c8b591753550",
+                "url": "https://api.github.com/repos/Freemius/wordpress-sdk/zipball/a4cc02a705639bcc64b5b55b8732432986b1b228",
+                "reference": "a4cc02a705639bcc64b5b55b8732432986b1b228",
                 "shasum": ""
             },
             "require": {
@@ -64,7 +64,7 @@
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "GPL-3.0"
+                "GPL-3.0-only"
             ],
             "description": "Freemius WordPress SDK",
             "homepage": "https://freemius.com",
@@ -74,24 +74,35 @@
                 "sdk",
                 "wordpress"
             ],
-            "time": "2017-12-19T08:42:21+00:00"
+            "time": "2019-02-25T18:19:27+00:00"
         },
         {
             "name": "gamajo/template-loader",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/GaryJones/Gamajo-Template-Loader.git",
-                "reference": "05057216f60baebfc4939e1a2b9aae6e89d25c91"
+                "reference": "fa92a37b780d945463f7fea328dce14933558752"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/GaryJones/Gamajo-Template-Loader/zipball/05057216f60baebfc4939e1a2b9aae6e89d25c91",
-                "reference": "05057216f60baebfc4939e1a2b9aae6e89d25c91",
+                "url": "https://api.github.com/repos/GaryJones/Gamajo-Template-Loader/zipball/fa92a37b780d945463f7fea328dce14933558752",
+                "reference": "fa92a37b780d945463f7fea328dce14933558752",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.2.4"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4",
+                "php": ">=7.1",
+                "phpcompatibility/phpcompatibility-wp": "^1",
+                "roave/security-advisories": "dev-master",
+                "squizlabs/php_codesniffer": "^3.3",
+                "wp-coding-standards/wpcs": "^1"
+            },
+            "suggest": {
+                "coenjacobs/mozart": "Easily wrap this library with your own prefix, to prevent collisions when multiple plugins use this library"
             },
             "type": "library",
             "autoload": {
@@ -101,23 +112,22 @@
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "GPL-2.0+"
+                "GPL-2.0-or-later"
             ],
             "authors": [
                 {
                     "name": "Gary Jones",
-                    "email": "gamajo@gamajo.com",
-                    "homepage": "http://gamajo.com",
+                    "homepage": "https://gamajo.com",
                     "role": "Developer"
                 }
             ],
             "description": "A class for your WordPress plugin, to allow loading template parts with fallback through the child theme > parent theme > plugin",
-            "homepage": "http://github.com/GaryJones/Gamajo-Template-Loader",
+            "homepage": "https://github.com/GaryJones/Gamajo-Template-Loader",
             "keywords": [
                 "templates",
                 "wordpress"
             ],
-            "time": "2017-03-24T17:28:34+00:00"
+            "time": "2018-09-24T10:23:49+00:00"
         }
     ],
     "packages-dev": [],
@@ -127,7 +137,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4"
+        "php": ">=5.6"
     },
     "platform-dev": []
 }

--- a/readme.txt
+++ b/readme.txt
@@ -225,6 +225,7 @@ Many thanks to the following:
 = Version 1.5.5 =
 * March 5, 2019
 * Now requires PHP version 5.6 or greater.
+* Now may disable upsells by adding `define( 'TK_EVENT_WEATHER_DISABLE_UPSELLS', true );` to `wp-config.php`.
 * Update Freemius SDK from v1.2.3 to v2.2.4 (security fix).
 
 = Version 1.5.4 =

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Requires at least: 4.6
 Tested up to: 4.9.4
 Requires PHP: 5.4
-Stable tag: 1.5.4
+Stable tag: 1.5.5
 
 Display beautiful, accurate, and free hourly weather forecasts between a start and end time. Perfect for event calendars.
 
@@ -222,6 +222,8 @@ Many thanks to the following:
 == Changelog ==
 *Changelog DIFFs for all versions are available at <a href="http://plugins.trac.wordpress.org/browser/tk-event-weather/trunk" target="_blank">WordPress SVN</a>.*
 
+= Version 1.5.5 =
+* March 5, 2019
 = Version 1.5.4 =
 * December 31, 2017
 * Now requires WordPress version 4.6 or greater, for the sake of translate.wordpress.org

--- a/readme.txt
+++ b/readme.txt
@@ -224,6 +224,8 @@ Many thanks to the following:
 
 = Version 1.5.5 =
 * March 5, 2019
+* Update Freemius SDK from v1.2.3 to v2.2.4 (security fix).
+
 = Version 1.5.4 =
 * December 31, 2017
 * Now requires WordPress version 4.6 or greater, for the sake of translate.wordpress.org

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: calendar, events, forecast, shortcode, weather
 License: GPL version 3 or any later version
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Requires at least: 4.6
-Tested up to: 4.9.4
+Tested up to: 5.1
 Requires PHP: 5.6
 Stable tag: 1.5.5
 
@@ -224,8 +224,9 @@ Many thanks to the following:
 
 = Version 1.5.5 =
 * March 5, 2019
+* Tested with WordPress 5.1
 * Now requires PHP version 5.6 or greater.
-* Now may disable upsells by adding `define( 'TK_EVENT_WEATHER_DISABLE_UPSELLS', true );` to `wp-config.php`.
+* Now may disable upsells by adding `define( 'TK_EVENT_WEATHER_DISABLE_UPSELLS', true );` to `wp-config.php`
 * Update Freemius SDK from v1.2.3 to v2.2.4 (security fix).
 
 = Version 1.5.4 =

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ License: GPL version 3 or any later version
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 Requires at least: 4.6
 Tested up to: 4.9.4
-Requires PHP: 5.4
+Requires PHP: 5.6
 Stable tag: 1.5.5
 
 Display beautiful, accurate, and free hourly weather forecasts between a start and end time. Perfect for event calendars.
@@ -180,7 +180,7 @@ This plugin will work with any properly-coded WordPress theme. Free styling / cu
 
 This plugin requires WordPress version 4.3.0 or later. It is always recommended to use the latest version of WordPress for compatibility, performance, and security reasons.
 
-This plugin may not work properly with PHP versions earlier than 5.4. You should meet or exceed the [WordPress recommended software specs](https://wordpress.org/about/requirements/) for best performance and security.
+This plugin may not work properly with PHP versions earlier than 5.6. You should meet or exceed the [WordPress recommended software specs](https://wordpress.org/about/requirements/) for best performance and security.
 
 Any of this plugin's add-ons for specific event calendars would require the latest version of each add-on plugin and each event calendar plugin.
 
@@ -224,6 +224,7 @@ Many thanks to the following:
 
 = Version 1.5.5 =
 * March 5, 2019
+* Now requires PHP version 5.6 or greater.
 * Update Freemius SDK from v1.2.3 to v2.2.4 (security fix).
 
 = Version 1.5.4 =

--- a/src/API_Google_Maps.php
+++ b/src/API_Google_Maps.php
@@ -169,7 +169,7 @@ class API_Google_Maps {
 		 * @link https://developers.google.com/maps/documentation/geocoding/intro#StatusCodes
 		 */
 		if ( 'OK' != $data->status ) {
-			return Functions::invalid_shortcode_message( 'The Google Maps Geocoding API resulted in an error: ' . $data->status . '.', 'https://developers.google.com/maps/documentation/geocoding/intro#StatusCodes' );
+			return Functions::invalid_shortcode_message( 'The Google Maps Geocoding API resulted in an error: ' . $data->status, 'https://developers.google.com/maps/documentation/geocoding/intro#StatusCodes' );
 		}
 
 		$latitude_longitude = '';

--- a/src/Addons.php
+++ b/src/Addons.php
@@ -77,6 +77,13 @@ class Addons {
 	 * @param $addon_dir
 	 */
 	private static function admin_notice_about_addon( $addon_dir ) {
+		if (
+			defined( 'TK_EVENT_WEATHER_DISABLE_UPSELLS' )
+			&& true === (bool) TK_EVENT_WEATHER_DISABLE_UPSELLS
+		) {
+			return;
+		}
+
 		$plugin_name = self::get_plugin_name_from_addon_dir( $addon_dir );
 
 		$message = sprintf(

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -31,7 +31,7 @@ class Setup {
 	 * @return string
 	 */
 	public static function min_php_version() {
-		return '5.4';
+		return '5.6';
 	}
 
 	/**

--- a/tk-event-weather.php
+++ b/tk-event-weather.php
@@ -5,7 +5,7 @@ namespace TKEventWeather;
 /*
 	Plugin Name: TK Event Weather
 	Plugin URI: https://tourkick.com/plugins/tk-event-weather/?utm_source=plugin-uri-link&utm_medium=free-plugin&utm_term=Event%20Weather%20plugin&utm_campaign=TK%20Event%20Weather
-	Version: 1.5.4
+	Version: 1.5.5
 	Author: TourKick (Clifford Paulick)
 	Author URI: https://tourkick.com/?utm_source=author-uri-link&utm_medium=free-plugin&utm_term=Event%20Weather%20plugin&utm_campaign=TK%20Event%20Weather
 	Description: Display beautiful, accurate, and free hourly weather forecasts between a start and end time. Perfect for event calendars.


### PR DESCRIPTION
= Version 1.5.5 =
* March 5, 2019
* Tested with WordPress 5.1
* Now requires PHP version 5.6 or greater.
* Now may disable upsells by adding `define( 'TK_EVENT_WEATHER_DISABLE_UPSELLS', true );` to `wp-config.php`
* Update Freemius SDK from v1.2.3 to v2.2.4 (security fix).

